### PR TITLE
Ft too often run jobs notification 153727848

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
 addons:
   postgresql: '9.4'
 script:
+- python manage.py makemigrations
+- python manage.py migrate
 - python manage.py collectstatic --noinput
 - coverage run --omit=*/tests/* --source=hc manage.py test
 after_success: coveralls

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -56,6 +56,7 @@ class Check(models.Model):
     alert_after = models.DateTimeField(null=True, blank=True, editable=False)
     nag_after = models.DateTimeField(null=True, blank=True, editable=False)
     status = models.CharField(max_length=6, choices=STATUSES, default="new")
+    often = models.BooleanField(default=False)
 
     def name_then_code(self):
         if self.name:

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -52,6 +52,7 @@ class Check(models.Model):
     last_ping = models.DateTimeField(null=True, blank=True)
     alert_after = models.DateTimeField(null=True, blank=True, editable=False)
     status = models.CharField(max_length=6, choices=STATUSES, default="new")
+    often = models.BooleanField(default=False)
 
     def name_then_code(self):
         if self.name:

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -145,14 +145,13 @@ STATICFILES_FINDERS = (
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 COMPRESS_OFFLINE = True
 
-EMAIL_BACKEND = 'djmail.backends.default.EmailBackend'
-DJMAIL_REAL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_PORT = 587
-EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')  # user email
-EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD') # user password
+DJMAIL_REAL_BACKEND = "djmail.backends.async.EmailBackend"
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "smtp.gmail.com"
+EMAIL_HOST_PORT = 587
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = True
-
 
 # Slack integration -- override these in local_settings
 SLACK_CLIENT_ID = None

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -147,7 +147,13 @@ STATICFILES_FINDERS = (
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 COMPRESS_OFFLINE = True
 
-EMAIL_BACKEND = "djmail.backends.default.EmailBackend"
+DJMAIL_REAL_BACKEND = "djmail.backends.async.EmailBackend"
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "smtp.gmail.com"
+EMAIL_HOST_PORT = 587
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+EMAIL_USE_TLS = True
 
 # Slack integration -- override these in local_settings
 SLACK_CLIENT_ID = None

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -146,7 +146,13 @@ STATICFILES_FINDERS = (
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 COMPRESS_OFFLINE = True
 
-EMAIL_BACKEND = "djmail.backends.default.EmailBackend"
+DJMAIL_REAL_BACKEND = "djmail.backends.async.EmailBackend"
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "smtp.gmail.com"
+EMAIL_HOST_PORT = 587
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+EMAIL_USE_TLS = True
 
 # Slack integration -- override these in local_settings
 SLACK_CLIENT_ID = None

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css">
     {% load compress staticfiles %}
     <link rel="icon" type="image/x-icon" href="{% static 'img/favicon.ico' %}">
 

--- a/templates/emails/alert-body-html.html
+++ b/templates/emails/alert-body-html.html
@@ -5,8 +5,18 @@
 <p>
     This is a notification sent by <a href="https://healthchecks.io">healthchecks.io</a>.
     <br />
-    The check <strong>{{ check.name_then_code }}</strong>
-    has gone <strong>{{ check.status|upper }}</strong>.
+    {% if check.often %}
+        {% if check.get_status == "up" %}
+            The check <strong>{{ check.name_then_code }}</strong>
+            is <strong>UP</strong> but is running too <strong>OFTEN</strong>.
+        {% else %}
+            The check <strong>{{ check.name_then_code }}</strong>
+            has gone <strong>{{ check.status|upper }}</strong>.
+        {% endif %}
+    {% else %}
+        The check <strong>{{ check.name_then_code }}</strong>
+        has gone <strong>{{ check.status|upper }}</strong>.
+    {% endif %}
 </p>
 
 <p>Here is a summary of all your checks:</p>

--- a/templates/emails/summary-html.html
+++ b/templates/emails/summary-html.html
@@ -30,6 +30,7 @@
     .up { background: #5cb85c; }
     .grace { background: #f0ad4e; }
     .down { background: #d9534f; }
+    .often { background: #3d53d1; }
 
 
     .unnamed {
@@ -62,7 +63,11 @@
             {% elif check.in_grace_period %}
                 <span class="badge grace">LATE</span>
             {% elif check.get_status == "up" %}
-                <span class="badge up">UP</span>
+                {% if check.often %}
+                    <span class="badge often">OFTEN</span>
+                {% else %}
+                    <span class="badge up">UP</span>
+                {% endif %}
             {% elif check.get_status == "down" %}
                 <span class="badge down">DOWN</span>
             {% endif %}

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -18,6 +18,39 @@
                 <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button> {% else %}
                 <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button> {% endif %} {% endfor %}
             </div>
+<table id="checks-table" class="table hidden-xs">
+    <tr>
+        <th></th>
+        <th class="th-name">Name</th>
+        <th>Ping URL</th>
+        <th class="th-period">
+            Period <br />
+            <span class="checks-subline">Grace</span>
+        </th>
+        <th>Last Ping</th>
+        <th></th>
+    </tr>
+    {% for check in checks %}
+    <tr class="checks-row">
+        <td class="indicator-cell">
+            {% if check.get_status == "new" %}
+                <span class="status icon-up new"
+                    data-toggle="tooltip" title="New. Has never received a ping."></span>
+            {% elif check.get_status == "paused" %}
+                <span class="status icon-paused"
+                    data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
+            {% elif check.in_grace_period %}
+                <span class="status icon-grace"></span>
+            {% elif check.get_status == "up" %}
+                {% if check.often %}
+                    <span style="color: #d9994f; font-size: 24px;">
+                        <i class="fa fa-clock-o" aria-hidden="true"></i>
+                    </i></span>
+                {% else %}
+                    <span class="status icon-up"></span>
+                {% endif %}
+            {% elif check.get_status == "down" %}
+                <span class="status icon-down"></span>
             {% endif %}
             <table id="checks-table" class="table hidden-xs">
                 <tr>

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -24,6 +24,39 @@
                     {% endif %}
                 {% endfor %}
             </div>
+<table id="checks-table" class="table hidden-xs">
+    <tr>
+        <th></th>
+        <th class="th-name">Name</th>
+        <th>Ping URL</th>
+        <th class="th-period">
+            Period <br />
+            <span class="checks-subline">Grace</span>
+        </th>
+        <th>Last Ping</th>
+        <th></th>
+    </tr>
+    {% for check in checks %}
+    <tr class="checks-row">
+        <td class="indicator-cell">
+            {% if check.get_status == "new" %}
+                <span class="status icon-up new"
+                    data-toggle="tooltip" title="New. Has never received a ping."></span>
+            {% elif check.get_status == "paused" %}
+                <span class="status icon-paused"
+                    data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
+            {% elif check.in_grace_period %}
+                <span class="status icon-grace"></span>
+            {% elif check.get_status == "up" %}
+                {% if check.often %}
+                    <span style="color: #d9994f; font-size: 24px;">
+                        <i class="fa fa-clock-o" aria-hidden="true"></i>
+                    </i></span>
+                {% else %}
+                    <span class="status icon-up"></span>
+                {% endif %}
+            {% elif check.get_status == "down" %}
+                <span class="status icon-down"></span>
             {% endif %}
             <table id="checks-table" class="table hidden-xs">
             <tr>

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -23,7 +23,13 @@
             {% elif check.in_grace_period %}
                 <span class="status icon-grace"></span>
             {% elif check.get_status == "up" %}
-                <span class="status icon-up"></span>
+                {% if check.often %}
+                    <span style="color: #d9994f; font-size: 24px;">
+                        <i class="fa fa-clock-o" aria-hidden="true"></i>
+                    </i></span>
+                {% else %}
+                    <span class="status icon-up"></span>
+                {% endif %}
             {% elif check.get_status == "down" %}
                 <span class="status icon-down"></span>
             {% endif %}

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -2,311 +2,219 @@
 <div>
     <br /><br />
     <!-- Nav tabs -->
-      <ul class="nav nav-tabs hidden-xs" role="tablist">
+    <ul class="nav nav-tabs hidden-xs" role="tablist">
         <li role="presentation" class="active"><a href="#all-checks" aria-controls="All" role="tab" data-toggle="tab">All</a></li>
         <li role="presentation"><a href="#unresolved-checks" aria-controls="Unresolved" role="tab" data-toggle="tab">Unresolved</a></li>
-      </ul>
+    </ul>
 
-      <!-- Tab panes -->
+    <!-- Tab panes -->
     <div class="tab-content hidden-xs">
         <div role="tabpanel" class="tab-pane fade in active" id="all-checks">
             {% if tags %}
             <br />
             <div id="my-checks-tags" class="col-sm-12">
-                <button class="btn btn-info btn-xs clear-all">Clear Filters</button>
-                {% for tag, count in tags %}
-                    {% if tag in down_tags %}
-                        <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
-                    {% elif tag in grace_tags %}
-                        <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button>
-                    {% else %}
-                        <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button>
-                    {% endif %}
-                {% endfor %}
+                <button class="btn btn-info btn-xs clear-all">Clear Filters</button> {% for tag, count in tags %} {% if tag in down_tags %}
+                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button> {% elif tag in grace_tags %}
+                <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button> {% else %}
+                <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button> {% endif %} {% endfor %}
             </div>
-<table id="checks-table" class="table hidden-xs">
-    <tr>
-        <th></th>
-        <th class="th-name">Name</th>
-        <th>Ping URL</th>
-        <th class="th-period">
-            Period <br />
-            <span class="checks-subline">Grace</span>
-        </th>
-        <th>Last Ping</th>
-        <th></th>
-    </tr>
-    {% for check in checks %}
-    <tr class="checks-row">
-        <td class="indicator-cell">
-            {% if check.get_status == "new" %}
-                <span class="status icon-up new"
-                    data-toggle="tooltip" title="New. Has never received a ping."></span>
-            {% elif check.get_status == "paused" %}
-                <span class="status icon-paused"
-                    data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
-            {% elif check.in_grace_period %}
-                <span class="status icon-grace"></span>
-            {% elif check.get_status == "up" %}
-                {% if check.often %}
-                    <span style="color: #d9994f; font-size: 24px;">
-                        <i class="fa fa-clock-o" aria-hidden="true"></i>
-                    </i></span>
-                {% else %}
-                    <span class="status icon-up"></span>
-                {% endif %}
-            {% elif check.get_status == "down" %}
-                <span class="status icon-down"></span>
             {% endif %}
             <table id="checks-table" class="table hidden-xs">
-            <tr>
-                <th></th>
-                <th class="th-name">Name</th>
-                <th>Ping URL</th>
-                <th class="th-period">
-                    Period <br />
-                    <span class="checks-subline">Grace</span>
-                </th>
-                <th>Last Ping</th>
-                <th></th>
-            </tr>
-            {% for check in checks %}
-            <tr class="checks-row">
-                <td class="indicator-cell">
-                    {% if check.get_status == "new" %}
-                        <span class="status icon-up new"
-                            data-toggle="tooltip" title="New. Has never received a ping."></span>
-                    {% elif check.get_status == "paused" %}
-                        <span class="status icon-paused"
-                            data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
-                    {% elif check.in_grace_period %}
-                        <span class="status icon-grace"></span>
-                    {% elif check.get_status == "up" %}
-                        {% if check.often %}
-                            <span style="color: #d9994f; font-size: 24px;">
-                                <i class="fa fa-clock-o" aria-hidden="true"></i>
-                            </span>
-                        {% else %}
-                            <span class="status icon-up"></span>
-                        {% endif %}
-                    {% elif check.get_status == "down" %}
-                        <span class="status icon-down"></span>
-                    {% endif %}
-                </td>
-                <td class="name-cell">
-                    <div data-name="{{ check.name }}"
-                            data-tags="{{ check.tags }}"
-                            data-url="{% url 'hc-update-name' check.code %}"
-                            class="my-checks-name {% if not check.name %}unnamed{% endif %}">
-                        <div>{{ check.name|default:"unnamed" }}</div>
-                        {% for tag in check.tags_list %}
-                        <span class="label label-tag">{{ tag }}</span>
-                        {% endfor %}
-                    </div>
-                </td>
-                <td class="url-cell">
-                    <span class="my-checks-url">
+                <tr>
+                    <th></th>
+                    <th class="th-name">Name</th>
+                    <th>Ping URL</th>
+                    <th class="th-period">
+                        Period <br />
+                        <span class="checks-subline">Grace</span>
+                    </th>
+                    <th>Last Ping</th>
+                    <th></th>
+                </tr>
+                {% for check in checks %}
+                <tr class="checks-row">
+                    <td class="indicator-cell">
+                        {% if check.get_status == "new" %}
+                        <span class="status icon-up new" data-toggle="tooltip" title="New. Has never received a ping."></span> {% elif check.get_status == "paused" %}
+                        <span class="status icon-paused" data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span> {% elif check.in_grace_period %}
+                        <span class="status icon-grace"></span> {% elif check.get_status == "up" %}
+                        {% if check.often %}<span style="color: #d9994f; font-size: 24px;"><i class="fa fa-clock-o" aria-hidden="true"></i></i></span>
+                        {% else %}<span class="status icon-up"></span>{% endif %}
+                        <span class="status icon-up"></span> {% elif check.get_status == "down" %}
+                        <span class="status icon-down"></span><span class="status icon-down"></span> {% endif %}
+                    </td>
+                    <td class="name-cell">
+                        <div data-name="{{ check.name }}" data-tags="{{ check.tags }}" data-url="{% url 'hc-update-name' check.code %}" class="my-checks-name {% if not check.name %}unnamed{% endif %}">
+                            <div>{{ check.name|default:"unnamed" }}</div>
+                            {% for tag in check.tags_list %}
+                            <span class="label label-tag">{{ tag }}</span> {% endfor %}
+                        </div>
+                    </td>
+                    <td class="url-cell">
+                        <span class="my-checks-url">
                         <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
-                    </span>
-                    <button
-                        class="copy-link hidden-sm"
-                        data-clipboard-text="{{ check.url }}">
+                        </span>
+                        <button class="copy-link hidden-sm" data-clipboard-text="{{ check.url }}">
                         copy
                     </button>
-                </td>
-                <td class="timeout-cell">
-                    <span
-                        data-url="{% url 'hc-update-timeout' check.code %}"
-                        data-timeout="{{ check.timeout.total_seconds }}"
-                        data-grace="{{ check.grace.total_seconds }}"
-                        class="timeout-grace">
+                    </td>
+                    <td class="timeout-cell">
+                        <span data-url="{% url 'hc-update-timeout' check.code %}" data-timeout="{{ check.timeout.total_seconds }}" data-grace="{{ check.grace.total_seconds }}" class="timeout-grace">
                         {{ check.timeout|hc_duration }}
                         <br />
                         <span class="checks-subline">
                         {{ check.grace|hc_duration }}
                         </span>
-                    </span>
-                </td>
-                <td>
-                {% if check.last_ping %}
-                    <span
-                        data-toggle="tooltip"
-                        title="{{ check.last_ping|date:'N j, Y, P e' }}">
+                        </span>
+                    </td>
+                    <td>
+                        {% if check.last_ping %}
+                        <span data-toggle="tooltip" title="{{ check.last_ping|date:'N j, Y, P e' }}">
                         {{ check.last_ping|naturaltime }}
-                    </span>
-                {% else %}
-                    Never
-                {% endif %}
-                </td>
-                <td>
-                    <div class="check-menu dropdown">
-                        <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                    </span> {% else %} Never {% endif %}
+                    </td>
+                    <td>
+                        <div class="check-menu dropdown">
+                            <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
                         <span class="icon-settings" aria-hidden="true"></span>
                         </button>
-                        <ul class="dropdown-menu">
-                            <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
-                                <a class="pause-check"
-                                   href="#"
-                                   data-url="{% url 'hc-pause' check.code %}">
+                            <ul class="dropdown-menu">
+                                {% if check.status == 'new' or check.status == 'paused' %}
+                                <li class="disabled">
+                                    {% else %}
+                                    <li>
+                                        {% endif %}
+                                        <a class="pause-check" href="#" data-url="{% url 'hc-pause' check.code %}">
                                    Pause Monitoring
                                 </a>
-                            </li>
-                            <li role="separator" class="divider"></li>
-                            <li>
-                                <a href="{% url 'hc-log' check.code %}">
+                                    </li>
+                                    <li role="separator" class="divider"></li>
+                                    <li>
+                                        <a href="{% url 'hc-log' check.code %}">
                                     Log
                                 </a>
-                            </li>
-                            <li>
-                                <a
-                                    href="#"
-                                    class="usage-examples"
-                                    data-url="{{ check.url }}"
-                                    data-email="{{ check.email }}">
+                                    </li>
+                                    <li>
+                                        <a href="#" class="usage-examples" data-url="{{ check.url }}" data-email="{{ check.email }}">
                                     Usage Examples
                                 </a>
-                            </li>
-                            <li role="separator" class="divider"></li>
-                            <li>
-                                <a href="#" class="check-menu-remove"
-                                    data-name="{{ check.name_then_code }}"
-                                    data-url="{% url 'hc-remove-check' check.code %}">
+                                    </li>
+                                    <li role="separator" class="divider"></li>
+                                    <li>
+                                        <a href="#" class="check-menu-remove" data-name="{{ check.name_then_code }}" data-url="{% url 'hc-remove-check' check.code %}">
                                     Remove
                                 </a>
-                            </li>
-                        </ul>
-                    </div>
-                </td>
-            </tr>
-            {% endfor %}
+                                    </li>
+                            </ul>
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
 
-        </table>
+            </table>
 
         </div>
         <div role="tabpanel" class="tab-pane fade" id="unresolved-checks">
-            {% if unresolved_checks %}
-            {% if tags %}
+            {% if unresolved_checks %} {% if tags %}
             <br />
             <div id="my-unresolved-checks-tags" class="col-sm-12">
-                <button class="btn btn-info btn-xs clear-all unresolved">Clear Filters</button>
-                {% for tag in down_tags %}
-                    <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
-                {% endfor %}
+                <button class="btn btn-info btn-xs clear-all unresolved">Clear Filters</button> {% for tag in down_tags %}
+                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button> {% endfor %}
             </div>
             {% endif %}
             <table id="unresolved-checks-table" class="table hidden-xs">
-            <tr>
-                <th></th>
-                <th class="th-name">Name</th>
-                <th>Ping URL</th>
-                <th class="th-period">
-                    Period <br />
-                    <span class="checks-subline">Grace</span>
-                </th>
-                <th>Last Ping</th>
-                <th></th>
-            </tr>
+                <tr>
+                    <th></th>
+                    <th class="th-name">Name</th>
+                    <th>Ping URL</th>
+                    <th class="th-period">
+                        Period <br />
+                        <span class="checks-subline">Grace</span>
+                    </th>
+                    <th>Last Ping</th>
+                    <th></th>
+                </tr>
 
-            {% for check in unresolved_checks %}
-            <tr class="checks-row">
-                <td class="indicator-cell">
+                {% for check in unresolved_checks %}
+                <tr class="checks-row">
+                    <td class="indicator-cell">
                         <span class="status icon-down"></span>
-                </td>
-                <td class="name-cell">
-                    <div data-name="{{ check.name }}"
-                            data-tags="{{ check.tags }}"
-                            data-url="{% url 'hc-update-name' check.code %}"
-                            class="my-checks-name {% if not check.name %}unnamed{% endif %}">
-                        <div>{{ check.name|default:"unnamed" }}</div>
-                        {% for tag in check.tags_list %}
-                        <span class="label label-tag">{{ tag }}</span>
-                        {% endfor %}
-                    </div>
-                </td>
-                <td class="url-cell">
-                    <span class="my-checks-url">
+                    </td>
+                    <td class="name-cell">
+                        <div data-name="{{ check.name }}" data-tags="{{ check.tags }}" data-url="{% url 'hc-update-name' check.code %}" class="my-checks-name {% if not check.name %}unnamed{% endif %}">
+                            <div>{{ check.name|default:"unnamed" }}</div>
+                            {% for tag in check.tags_list %}
+                            <span class="label label-tag">{{ tag }}</span> {% endfor %}
+                        </div>
+                    </td>
+                    <td class="url-cell">
+                        <span class="my-checks-url">
                         <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
-                    </span>
-                    <button
-                        class="copy-link hidden-sm"
-                        data-clipboard-text="{{ check.url }}">
+                        </span>
+                        <button class="copy-link hidden-sm" data-clipboard-text="{{ check.url }}">
                         copy
                     </button>
-                </td>
-                <td class="timeout-cell">
-                    <span
-                        data-url="{% url 'hc-update-timeout' check.code %}"
-                        data-timeout="{{ check.timeout.total_seconds }}"
-                        data-grace="{{ check.grace.total_seconds }}"
-                        class="timeout-grace">
+                    </td>
+                    <td class="timeout-cell">
+                        <span data-url="{% url 'hc-update-timeout' check.code %}" data-timeout="{{ check.timeout.total_seconds }}" data-grace="{{ check.grace.total_seconds }}" class="timeout-grace">
                         {{ check.timeout|hc_duration }}
                         <br />
                         <span class="checks-subline">
                         {{ check.grace|hc_duration }}
                         </span>
-                    </span>
-                </td>
-                <td>
-                {% if check.last_ping %}
-                    <span
-                        data-toggle="tooltip"
-                        title="{{ check.last_ping|date:'N j, Y, P e' }}">
+                        </span>
+                    </td>
+                    <td>
+                        {% if check.last_ping %}
+                        <span data-toggle="tooltip" title="{{ check.last_ping|date:'N j, Y, P e' }}">
                         {{ check.last_ping|naturaltime }}
-                    </span>
-                {% else %}
-                    Never
-                {% endif %}
-                </td>
-                <td>
-                    <div class="check-menu dropdown">
-                        <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                    </span> {% else %} Never {% endif %}
+                    </td>
+                    <td>
+                        <div class="check-menu dropdown">
+                            <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
                         <span class="icon-settings" aria-hidden="true"></span>
                         </button>
-                        <ul class="dropdown-menu">
-                            <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
-                                <a class="pause-check"
-                                   href="#"
-                                   data-url="{% url 'hc-pause' check.code %}">
+                            <ul class="dropdown-menu">
+                                {% if check.status == 'new' or check.status == 'paused' %}
+                                <li class="disabled">
+                                    {% else %}
+                                    <li>
+                                        {% endif %}
+                                        <a class="pause-check" href="#" data-url="{% url 'hc-pause' check.code %}">
                                    Pause Monitoring
                                 </a>
-                            </li>
-                            <li role="separator" class="divider"></li>
-                            <li>
-                                <a href="{% url 'hc-log' check.code %}">
+                                    </li>
+                                    <li role="separator" class="divider"></li>
+                                    <li>
+                                        <a href="{% url 'hc-log' check.code %}">
                                     Log
                                 </a>
-                            </li>
-                            <li>
-                                <a
-                                    href="#"
-                                    class="usage-examples"
-                                    data-url="{{ check.url }}"
-                                    data-email="{{ check.email }}">
+                                    </li>
+                                    <li>
+                                        <a href="#" class="usage-examples" data-url="{{ check.url }}" data-email="{{ check.email }}">
                                     Usage Examples
                                 </a>
-                            </li>
-                            <li role="separator" class="divider"></li>
-                            <li>
-                                <a href="#" class="check-menu-remove"
-                                    data-name="{{ check.name_then_code }}"
-                                    data-url="{% url 'hc-remove-check' check.code %}">
+                                    </li>
+                                    <li role="separator" class="divider"></li>
+                                    <li>
+                                        <a href="#" class="check-menu-remove" data-name="{{ check.name_then_code }}" data-url="{% url 'hc-remove-check' check.code %}">
                                     Remove
                                 </a>
-                            </li>
-                        </ul>
-                    </div>
-                </td>
-            </tr>
-            {% endfor %}
+                                    </li>
+                            </ul>
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
 
-        </table>
-        {% else %}
-        <br />
+            </table>
+            {% else %}
+            <br />
             <div class="text-center alert alert-info">You don't have any unresolved checks.</div>
-        {% endif %}
+            {% endif %}
 
         </div>
     </div>
-
 
 </div>

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -2,217 +2,278 @@
 <div>
     <br /><br />
     <!-- Nav tabs -->
-    <ul class="nav nav-tabs hidden-xs" role="tablist">
+      <ul class="nav nav-tabs hidden-xs" role="tablist">
         <li role="presentation" class="active"><a href="#all-checks" aria-controls="All" role="tab" data-toggle="tab">All</a></li>
         <li role="presentation"><a href="#unresolved-checks" aria-controls="Unresolved" role="tab" data-toggle="tab">Unresolved</a></li>
-    </ul>
+      </ul>
 
-    <!-- Tab panes -->
+      <!-- Tab panes -->
     <div class="tab-content hidden-xs">
         <div role="tabpanel" class="tab-pane fade in active" id="all-checks">
             {% if tags %}
             <br />
             <div id="my-checks-tags" class="col-sm-12">
-                <button class="btn btn-info btn-xs clear-all">Clear Filters</button> {% for tag, count in tags %} {% if tag in down_tags %}
-                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button> {% elif tag in grace_tags %}
-                <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button> {% else %}
-                <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button> {% endif %} {% endfor %}
+                <button class="btn btn-info btn-xs clear-all">Clear Filters</button>
+                {% for tag, count in tags %}
+                    {% if tag in down_tags %}
+                        <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
+                    {% elif tag in grace_tags %}
+                        <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button>
+                    {% else %}
+                        <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button>
+                    {% endif %}
+                {% endfor %}
             </div>
             {% endif %}
             <table id="checks-table" class="table hidden-xs">
-                <tr>
-                    <th></th>
-                    <th class="th-name">Name</th>
-                    <th>Ping URL</th>
-                    <th class="th-period">
-                        Period <br />
-                        <span class="checks-subline">Grace</span>
-                    </th>
-                    <th>Last Ping</th>
-                    <th></th>
-                </tr>
-                {% for check in checks %}
-                <tr class="checks-row">
-                    <td class="indicator-cell">
-                        {% if check.get_status == "new" %}
-                        <span class="status icon-up new" data-toggle="tooltip" title="New. Has never received a ping."></span> {% elif check.get_status == "paused" %}
-                        <span class="status icon-paused" data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span> {% elif check.in_grace_period %}
-                        <span class="status icon-grace"></span> {% elif check.get_status == "up" %}
-                        <span class="status icon-up"></span> {% elif check.get_status == "down" %}
-                        <span class="status icon-down"></span><span class="status icon-down"></span> {% endif %}
-                    </td>
-                    <td class="name-cell">
-                        <div data-name="{{ check.name }}" data-tags="{{ check.tags }}" data-url="{% url 'hc-update-name' check.code %}" class="my-checks-name {% if not check.name %}unnamed{% endif %}">
-                            <div>{{ check.name|default:"unnamed" }}</div>
-                            {% for tag in check.tags_list %}
-                            <span class="label label-tag">{{ tag }}</span> {% endfor %}
-                        </div>
-                    </td>
-                    <td class="url-cell">
-                        <span class="my-checks-url">
+            <tr>
+                <th></th>
+                <th class="th-name">Name</th>
+                <th>Ping URL</th>
+                <th class="th-period">
+                    Period <br />
+                    <span class="checks-subline">Grace</span>
+                </th>
+                <th>Last Ping</th>
+                <th></th>
+            </tr>
+            {% for check in checks %}
+            <tr class="checks-row">
+                <td class="indicator-cell">
+                    {% if check.get_status == "new" %}
+                        <span class="status icon-up new"
+                            data-toggle="tooltip" title="New. Has never received a ping."></span>
+                    {% elif check.get_status == "paused" %}
+                        <span class="status icon-paused"
+                            data-toggle="tooltip" title="Monitoring paused. Ping to resume."></span>
+                    {% elif check.in_grace_period %}
+                        <span class="status icon-grace"></span>
+                    {% elif check.get_status == "up" %}
+                        {% if check.often %}
+                            <span style="color: #d9994f; font-size: 24px;">
+                                <i class="fa fa-clock-o" aria-hidden="true"></i>
+                            </span>
+                        {% else %}
+                            <span class="status icon-up"></span>
+                        {% endif %}
+                    {% elif check.get_status == "down" %}
+                        <span class="status icon-down"></span>
+                    {% endif %}
+                </td>
+                <td class="name-cell">
+                    <div data-name="{{ check.name }}"
+                            data-tags="{{ check.tags }}"
+                            data-url="{% url 'hc-update-name' check.code %}"
+                            class="my-checks-name {% if not check.name %}unnamed{% endif %}">
+                        <div>{{ check.name|default:"unnamed" }}</div>
+                        {% for tag in check.tags_list %}
+                        <span class="label label-tag">{{ tag }}</span>
+                        {% endfor %}
+                    </div>
+                </td>
+                <td class="url-cell">
+                    <span class="my-checks-url">
                         <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
-                        </span>
-                        <button class="copy-link hidden-sm" data-clipboard-text="{{ check.url }}">
+                    </span>
+                    <button
+                        class="copy-link hidden-sm"
+                        data-clipboard-text="{{ check.url }}">
                         copy
                     </button>
-                    </td>
-                    <td class="timeout-cell">
-                        <span data-url="{% url 'hc-update-timeout' check.code %}" data-timeout="{{ check.timeout.total_seconds }}" data-grace="{{ check.grace.total_seconds }}" class="timeout-grace">
+                </td>
+                <td class="timeout-cell">
+                    <span
+                        data-url="{% url 'hc-update-timeout' check.code %}"
+                        data-timeout="{{ check.timeout.total_seconds }}"
+                        data-grace="{{ check.grace.total_seconds }}"
+                        class="timeout-grace">
                         {{ check.timeout|hc_duration }}
                         <br />
                         <span class="checks-subline">
                         {{ check.grace|hc_duration }}
                         </span>
-                        </span>
-                    </td>
-                    <td>
-                        {% if check.last_ping %}
-                        <span data-toggle="tooltip" title="{{ check.last_ping|date:'N j, Y, P e' }}">
+                    </span>
+                </td>
+                <td>
+                {% if check.last_ping %}
+                    <span
+                        data-toggle="tooltip"
+                        title="{{ check.last_ping|date:'N j, Y, P e' }}">
                         {{ check.last_ping|naturaltime }}
-                    </span> {% else %} Never {% endif %}
-                    </td>
-                    <td>
-                        <div class="check-menu dropdown">
-                            <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                    </span>
+                {% else %}
+                    Never
+                {% endif %}
+                </td>
+                <td>
+                    <div class="check-menu dropdown">
+                        <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
                         <span class="icon-settings" aria-hidden="true"></span>
                         </button>
-                            <ul class="dropdown-menu">
-                                {% if check.status == 'new' or check.status == 'paused' %}
-                                <li class="disabled">
-                                    {% else %}
-                                    <li>
-                                        {% endif %}
-                                        <a class="pause-check" href="#" data-url="{% url 'hc-pause' check.code %}">
+                        <ul class="dropdown-menu">
+                            <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
+                                <a class="pause-check"
+                                   href="#"
+                                   data-url="{% url 'hc-pause' check.code %}">
                                    Pause Monitoring
                                 </a>
-                                    </li>
-                                    <li role="separator" class="divider"></li>
-                                    <li>
-                                        <a href="{% url 'hc-log' check.code %}">
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li>
+                                <a href="{% url 'hc-log' check.code %}">
                                     Log
                                 </a>
-                                    </li>
-                                    <li>
-                                        <a href="#" class="usage-examples" data-url="{{ check.url }}" data-email="{{ check.email }}">
+                            </li>
+                            <li>
+                                <a
+                                    href="#"
+                                    class="usage-examples"
+                                    data-url="{{ check.url }}"
+                                    data-email="{{ check.email }}">
                                     Usage Examples
                                 </a>
-                                    </li>
-                                    <li role="separator" class="divider"></li>
-                                    <li>
-                                        <a href="#" class="check-menu-remove" data-name="{{ check.name_then_code }}" data-url="{% url 'hc-remove-check' check.code %}">
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li>
+                                <a href="#" class="check-menu-remove"
+                                    data-name="{{ check.name_then_code }}"
+                                    data-url="{% url 'hc-remove-check' check.code %}">
                                     Remove
                                 </a>
-                                    </li>
-                            </ul>
-                        </div>
-                    </td>
-                </tr>
-                {% endfor %}
+                            </li>
+                        </ul>
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
 
-            </table>
+        </table>
 
         </div>
         <div role="tabpanel" class="tab-pane fade" id="unresolved-checks">
-            {% if unresolved_checks %} {% if tags %}
+            {% if unresolved_checks %}
+            {% if tags %}
             <br />
             <div id="my-unresolved-checks-tags" class="col-sm-12">
-                <button class="btn btn-info btn-xs clear-all unresolved">Clear Filters</button> {% for tag in down_tags %}
-                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button> {% endfor %}
+                <button class="btn btn-info btn-xs clear-all unresolved">Clear Filters</button>
+                {% for tag in down_tags %}
+                    <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
+                {% endfor %}
             </div>
             {% endif %}
             <table id="unresolved-checks-table" class="table hidden-xs">
-                <tr>
-                    <th></th>
-                    <th class="th-name">Name</th>
-                    <th>Ping URL</th>
-                    <th class="th-period">
-                        Period <br />
-                        <span class="checks-subline">Grace</span>
-                    </th>
-                    <th>Last Ping</th>
-                    <th></th>
-                </tr>
+            <tr>
+                <th></th>
+                <th class="th-name">Name</th>
+                <th>Ping URL</th>
+                <th class="th-period">
+                    Period <br />
+                    <span class="checks-subline">Grace</span>
+                </th>
+                <th>Last Ping</th>
+                <th></th>
+            </tr>
 
-                {% for check in unresolved_checks %}
-                <tr class="checks-row">
-                    <td class="indicator-cell">
+            {% for check in unresolved_checks %}
+            <tr class="checks-row">
+                <td class="indicator-cell">
                         <span class="status icon-down"></span>
-                    </td>
-                    <td class="name-cell">
-                        <div data-name="{{ check.name }}" data-tags="{{ check.tags }}" data-url="{% url 'hc-update-name' check.code %}" class="my-checks-name {% if not check.name %}unnamed{% endif %}">
-                            <div>{{ check.name|default:"unnamed" }}</div>
-                            {% for tag in check.tags_list %}
-                            <span class="label label-tag">{{ tag }}</span> {% endfor %}
-                        </div>
-                    </td>
-                    <td class="url-cell">
-                        <span class="my-checks-url">
+                </td>
+                <td class="name-cell">
+                    <div data-name="{{ check.name }}"
+                            data-tags="{{ check.tags }}"
+                            data-url="{% url 'hc-update-name' check.code %}"
+                            class="my-checks-name {% if not check.name %}unnamed{% endif %}">
+                        <div>{{ check.name|default:"unnamed" }}</div>
+                        {% for tag in check.tags_list %}
+                        <span class="label label-tag">{{ tag }}</span>
+                        {% endfor %}
+                    </div>
+                </td>
+                <td class="url-cell">
+                    <span class="my-checks-url">
                         <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
-                        </span>
-                        <button class="copy-link hidden-sm" data-clipboard-text="{{ check.url }}">
+                    </span>
+                    <button
+                        class="copy-link hidden-sm"
+                        data-clipboard-text="{{ check.url }}">
                         copy
                     </button>
-                    </td>
-                    <td class="timeout-cell">
-                        <span data-url="{% url 'hc-update-timeout' check.code %}" data-timeout="{{ check.timeout.total_seconds }}" data-grace="{{ check.grace.total_seconds }}" class="timeout-grace">
+                </td>
+                <td class="timeout-cell">
+                    <span
+                        data-url="{% url 'hc-update-timeout' check.code %}"
+                        data-timeout="{{ check.timeout.total_seconds }}"
+                        data-grace="{{ check.grace.total_seconds }}"
+                        class="timeout-grace">
                         {{ check.timeout|hc_duration }}
                         <br />
                         <span class="checks-subline">
                         {{ check.grace|hc_duration }}
                         </span>
-                        </span>
-                    </td>
-                    <td>
-                        {% if check.last_ping %}
-                        <span data-toggle="tooltip" title="{{ check.last_ping|date:'N j, Y, P e' }}">
+                    </span>
+                </td>
+                <td>
+                {% if check.last_ping %}
+                    <span
+                        data-toggle="tooltip"
+                        title="{{ check.last_ping|date:'N j, Y, P e' }}">
                         {{ check.last_ping|naturaltime }}
-                    </span> {% else %} Never {% endif %}
-                    </td>
-                    <td>
-                        <div class="check-menu dropdown">
-                            <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                    </span>
+                {% else %}
+                    Never
+                {% endif %}
+                </td>
+                <td>
+                    <div class="check-menu dropdown">
+                        <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
                         <span class="icon-settings" aria-hidden="true"></span>
                         </button>
-                            <ul class="dropdown-menu">
-                                {% if check.status == 'new' or check.status == 'paused' %}
-                                <li class="disabled">
-                                    {% else %}
-                                    <li>
-                                        {% endif %}
-                                        <a class="pause-check" href="#" data-url="{% url 'hc-pause' check.code %}">
+                        <ul class="dropdown-menu">
+                            <li {% if check.status == "new" or check.status == "paused" %}class="disabled"{% endif %}>
+                                <a class="pause-check"
+                                   href="#"
+                                   data-url="{% url 'hc-pause' check.code %}">
                                    Pause Monitoring
                                 </a>
-                                    </li>
-                                    <li role="separator" class="divider"></li>
-                                    <li>
-                                        <a href="{% url 'hc-log' check.code %}">
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li>
+                                <a href="{% url 'hc-log' check.code %}">
                                     Log
                                 </a>
-                                    </li>
-                                    <li>
-                                        <a href="#" class="usage-examples" data-url="{{ check.url }}" data-email="{{ check.email }}">
+                            </li>
+                            <li>
+                                <a
+                                    href="#"
+                                    class="usage-examples"
+                                    data-url="{{ check.url }}"
+                                    data-email="{{ check.email }}">
                                     Usage Examples
                                 </a>
-                                    </li>
-                                    <li role="separator" class="divider"></li>
-                                    <li>
-                                        <a href="#" class="check-menu-remove" data-name="{{ check.name_then_code }}" data-url="{% url 'hc-remove-check' check.code %}">
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li>
+                                <a href="#" class="check-menu-remove"
+                                    data-name="{{ check.name_then_code }}"
+                                    data-url="{% url 'hc-remove-check' check.code %}">
                                     Remove
                                 </a>
-                                    </li>
-                            </ul>
-                        </div>
-                    </td>
-                </tr>
-                {% endfor %}
+                            </li>
+                        </ul>
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
 
-            </table>
-            {% else %}
-            <br />
+        </table>
+        {% else %}
+        <br />
             <div class="text-center alert alert-info">You don't have any unresolved checks.</div>
-            {% endif %}
+        {% endif %}
 
         </div>
     </div>
+
 
 </div>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -98,13 +98,30 @@
                         <td>{{ check.grace|hc_duration }}</td>
                     </tr>
                     <tr>
-                <th>Last Ping</th>
-                <td>
-                    {% if check.last_ping %}
-                        {{ check.last_ping|naturaltime }}
-                    {% else %}
-                        Never
-                    {% endif %}
+                        <th>Last Ping</th>
+                        <td>
+                            {% if check.last_ping %}
+                                {{ check.last_ping|naturaltime }}
+                            {% else %}
+                                Never
+                            {% endif %}
+                    <tr>
+                        <th>Period</th>
+                        <td>{{ check.timeout|hc_duration }}</td>
+                    </tr>
+                    <tr>
+                        <th>Grace Time</th>
+                        <td>{{ check.grace|hc_duration }}</td>
+                    </tr>
+                    <tr>
+                        <th>Last Ping</th>
+                        <td>
+                            {% if check.last_ping %}
+                                {{ check.last_ping|naturaltime }}
+                            {% else %}
+                                Never
+                            {% endif %}
+                        </td>
                     <tr>
                         <th>Period</th>
                         <td>{{ check.timeout|hc_duration }}</td>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -216,6 +216,23 @@
                             {% endfor %}
                         </td>
                     </tr>
+
+            {% endif %}
+            <tr>
+                <th>Period</th>
+                <td>{{ check.timeout|hc_duration }}</td>
+            </tr>
+            <tr>
+                <th>Grace Time</th>
+                <td>{{ check.grace|hc_duration }}</td>
+            </tr>
+            <tr>
+                <th>Last Ping</th>
+                <td>
+                    {% if check.last_ping %}
+                        {{ check.last_ping|naturaltime }}
+                    {% else %}
+                        Never
                     {% endif %}
                     <tr>
                         <th>Period</th>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -33,6 +33,8 @@
                         <span class="label label-success">UP</span>
                     {% elif check.get_status == "down" %}
                         <span class="label label-danger">DOWN</span>
+                    {% elif check.often %}
+                        <span class="label label-primary">OFTEN</span>
                     {% endif %}
                 </td>
             </tr>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -32,10 +32,10 @@
                     <span class="{% if not check.name %}unnamed{% endif %}">
                         {{ check.name|default:"unnamed" }}
                     </span>
-
+        
                     <code>{{ check.code }}</code>
                 </h2>
-
+        
                 <a
                     href="#"
                     class="btn remove-link check-menu-remove"
@@ -43,7 +43,7 @@
                     data-url="{% url 'hc-remove-check' check.code %}">
                     <span class="icon-close"></span>
                 </a>
-
+        
                 <table class="table">
                     <tr>
                         <th>Status</th>
@@ -58,6 +58,8 @@
                                 <span class="label label-success">UP</span>
                             {% elif check.get_status == "down" %}
                                 <span class="label label-danger">DOWN</span>
+                            {% elif check.often %}
+                                <span class="label label-primary">OFTEN</span>
                             {% endif %}
                         </td>
                     </tr>
@@ -70,6 +72,23 @@
                             {% endfor %}
                         </td>
                     </tr>
+
+            {% endif %}
+            <tr>
+                <th>Period</th>
+                <td>{{ check.timeout|hc_duration }}</td>
+            </tr>
+            <tr>
+                <th>Grace Time</th>
+                <td>{{ check.grace|hc_duration }}</td>
+            </tr>
+            <tr>
+                <th>Last Ping</th>
+                <td>
+                    {% if check.last_ping %}
+                        {{ check.last_ping|naturaltime }}
+                    {% else %}
+                        Never
                     {% endif %}
                     <tr>
                         <th>Period</th>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -32,10 +32,10 @@
                     <span class="{% if not check.name %}unnamed{% endif %}">
                         {{ check.name|default:"unnamed" }}
                     </span>
-
+        
                     <code>{{ check.code }}</code>
                 </h2>
-
+        
                 <a
                     href="#"
                     class="btn remove-link check-menu-remove"
@@ -43,7 +43,7 @@
                     data-url="{% url 'hc-remove-check' check.code %}">
                     <span class="icon-close"></span>
                 </a>
-
+        
                 <table class="table">
                     <tr>
                         <th>Status</th>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -32,10 +32,10 @@
                     <span class="{% if not check.name %}unnamed{% endif %}">
                         {{ check.name|default:"unnamed" }}
                     </span>
-
+        
                     <code>{{ check.code }}</code>
                 </h2>
-
+        
                 <a
                     href="#"
                     class="btn remove-link check-menu-remove"
@@ -43,7 +43,7 @@
                     data-url="{% url 'hc-remove-check' check.code %}">
                     <span class="icon-close"></span>
                 </a>
-
+        
                 <table class="table">
                     <tr>
                         <th>Status</th>
@@ -58,6 +58,8 @@
                                 <span class="label label-success">UP</span>
                             {% elif check.get_status == "down" %}
                                 <span class="label label-danger">DOWN</span>
+                            {% elif check.often %}
+                                <span class="label label-primary">OFTEN</span>
                             {% endif %}
                         </td>
                     </tr>
@@ -70,6 +72,22 @@
                             {% endfor %}
                         </td>
                     </tr>
+                    {% endif %}
+                    <tr>
+                        <th>Period</th>
+                        <td>{{ check.timeout|hc_duration }}</td>
+                    </tr>
+                    <tr>
+                        <th>Grace Time</th>
+                        <td>{{ check.grace|hc_duration }}</td>
+                    </tr>
+                    <tr>
+                <th>Last Ping</th>
+                <td>
+                    {% if check.last_ping %}
+                        {{ check.last_ping|naturaltime }}
+                    {% else %}
+                        Never
                     {% endif %}
                     <tr>
                         <th>Period</th>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -72,6 +72,23 @@
                             {% endfor %}
                         </td>
                     </tr>
+
+            {% endif %}
+            <tr>
+                <th>Period</th>
+                <td>{{ check.timeout|hc_duration }}</td>
+            </tr>
+            <tr>
+                <th>Grace Time</th>
+                <td>{{ check.grace|hc_duration }}</td>
+            </tr>
+            <tr>
+                <th>Last Ping</th>
+                <td>
+                    {% if check.last_ping %}
+                        {{ check.last_ping|naturaltime }}
+                    {% else %}
+                        Never
                     {% endif %}
                     <tr>
                         <th>Period</th>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -57,19 +57,37 @@
                             {% elif check.get_status == "up" %}
                                 <span class="label label-success">UP</span>
                             {% elif check.get_status == "down" %}
-                                <span class="label label-danger">DOWN</span>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% if check.tags %}
-                    <tr>
-                        <th>Tags</th>
-                        <td>
-                            {% for tag in check.tags_list %}
-                            <span class="label label-tag">{{ tag }}</span>
-                            {% endfor %}
-                        </td>
-                    </tr>
+                        <span class="label label-danger">DOWN</span>
+                    {% elif check.often %}
+                        <span class="label label-primary">OFTEN</span>
+                    {% endif %}
+                </td>
+            </tr>
+            {% if check.tags %}
+            <tr>
+                <th>Tags</th>
+                <td>
+                    {% for tag in check.tags_list %}
+                    <span class="label label-tag">{{ tag }}</span>
+                    {% endfor %}
+                </td>
+            </tr>
+            {% endif %}
+            <tr>
+                <th>Period</th>
+                <td>{{ check.timeout|hc_duration }}</td>
+            </tr>
+            <tr>
+                <th>Grace Time</th>
+                <td>{{ check.grace|hc_duration }}</td>
+            </tr>
+            <tr>
+                <th>Last Ping</th>
+                <td>
+                    {% if check.last_ping %}
+                        {{ check.last_ping|naturaltime }}
+                    {% else %}
+                        Never
                     {% endif %}
                     <tr>
                         <th>Period</th>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -82,13 +82,30 @@
                         <td>{{ check.grace|hc_duration }}</td>
                     </tr>
                     <tr>
-                <th>Last Ping</th>
-                <td>
-                    {% if check.last_ping %}
-                        {{ check.last_ping|naturaltime }}
-                    {% else %}
-                        Never
-                    {% endif %}
+                        <th>Last Ping</th>
+                        <td>
+                            {% if check.last_ping %}
+                                {{ check.last_ping|naturaltime }}
+                            {% else %}
+                                Never
+                            {% endif %}
+                    <tr>
+                        <th>Period</th>
+                        <td>{{ check.timeout|hc_duration }}</td>
+                    </tr>
+                    <tr>
+                        <th>Grace Time</th>
+                        <td>{{ check.grace|hc_duration }}</td>
+                    </tr>
+                    <tr>
+                        <th>Last Ping</th>
+                        <td>
+                            {% if check.last_ping %}
+                                {{ check.last_ping|naturaltime }}
+                            {% else %}
+                                Never
+                            {% endif %}
+                        </td>
                     <tr>
                         <th>Period</th>
                         <td>{{ check.timeout|hc_duration }}</td>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -57,22 +57,21 @@
                             {% elif check.get_status == "up" %}
                                 <span class="label label-success">UP</span>
                             {% elif check.get_status == "down" %}
-                                <span class="label label-danger">DOWN</span>
-                            {% elif check.often %}
-                                <span class="label label-primary">OFTEN</span>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% if check.tags %}
-                    <tr>
-                        <th>Tags</th>
-                        <td>
-                            {% for tag in check.tags_list %}
-                            <span class="label label-tag">{{ tag }}</span>
-                            {% endfor %}
-                        </td>
-                    </tr>
-
+                        <span class="label label-danger">DOWN</span>
+                    {% elif check.often %}
+                        <span class="label label-primary">OFTEN</span>
+                    {% endif %}
+                </td>
+            </tr>
+            {% if check.tags %}
+            <tr>
+                <th>Tags</th>
+                <td>
+                    {% for tag in check.tags_list %}
+                    <span class="label label-tag">{{ tag }}</span>
+                    {% endfor %}
+                </td>
+            </tr>
             {% endif %}
             <tr>
                 <th>Period</th>

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -98,6 +98,22 @@
                         <td>{{ check.grace|hc_duration }}</td>
                     </tr>
                     <tr>
+                <th>Last Ping</th>
+                <td>
+                    {% if check.last_ping %}
+                        {{ check.last_ping|naturaltime }}
+                    {% else %}
+                        Never
+                    {% endif %}
+                    <tr>
+                        <th>Period</th>
+                        <td>{{ check.timeout|hc_duration }}</td>
+                    </tr>
+                    <tr>
+                        <th>Grace Time</th>
+                        <td>{{ check.grace|hc_duration }}</td>
+                    </tr>
+                    <tr>
                         <th>Last Ping</th>
                         <td>
                             {% if check.last_ping %}


### PR DESCRIPTION
## PR Status
**READY**

## Story ID
[#153727848](https://www.pivotaltracker.com/story/show/153727848)

## Added Migrations
YES

![image](https://user-images.githubusercontent.com/30072633/35349570-5d289e90-014c-11e8-807c-7f756299f7d9.png)


## Description
The system notifies the user of jobs that are late to run.
When this PR is reviewed, corrected where necessary and merged, the user will be able to receive notifications for when their `jobs run to often`.

### What does running too often mean?

A job can be considered as running too often when it is run before the set Timeout period. We can set a 'reversed' Grace period before which a job should not run.
_For example.._
>A job with a timeout period of 1 hour and a Grace period of 10 minutes means the job can run at the 60th minute or any time between the 60th and the 70th minutes since the Grace period is 10 minutes. However, with a reversed Grace period of 10 minutes, the job can then run anytime between the 50th minute and the 70th minute. If that job runs before the 50th minute then it can be characterised as running too often

## New Packages Added
None

## Related PRs 
List related PRs against other branches:

branch | PR
------ | ------
samachola:nag-interval-#153727845 | [Nag interval](https://github.com/andela/hc-anansi/pull/19)


## Todos
- [x] Tested and working locally
- [x] Tested and working on development environment
- [x] Added more Unit tests
- [x] Reviewed and approved by the scrum master
- [x] Reviewed and approved by a TTL
- [x] Deployment to team Heroku account


## Impacted Areas in the application
User alerts and notifications.

## Known Issues (optional)
There seems to be an issue when a user sets a `grace period` that is `equal` or `greater than` the `timeout`.



